### PR TITLE
Fix for Windows platform

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
       let livewireClassPath = (await fs.existsSync(vscode.workspace.workspaceFolders[0].uri.fsPath + '/app/Http/Livewire')) ? 'app/Http/Livewire/' : 'app/Livewire/';
 
       if (vscode.workspace.asRelativePath(vscode.window.activeTextEditor?.document.fileName).startsWith('resources/views/livewire/')) {
-        const relativePath = vscode.window.activeTextEditor?.document.fileName.split('resources/views/livewire/')[1];
+        const relativePath = vscode.workspace.asRelativePath(vscode.window.activeTextEditor?.document.fileName).split('resources/views/livewire/')[1];
         let file = relativePath
           .replace('.blade.php', '')
           .split('/')
@@ -34,7 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
         const document = await vscode.workspace.openTextDocument(vscode.workspace.workspaceFolders[0].uri.path + '/' + livewireClassPath + file);
         await vscode.window.showTextDocument(document);
       } else if (vscode.workspace.asRelativePath(vscode.window.activeTextEditor?.document.fileName).startsWith(livewireClassPath)) {
-        const relativePath = vscode.window.activeTextEditor?.document.fileName.split(livewireClassPath)[1];
+        const relativePath = vscode.workspace.asRelativePath(vscode.window.activeTextEditor?.document.fileName).split(livewireClassPath)[1];
         let file = relativePath
           .split('/')
           .map((d, index, array) => {


### PR DESCRIPTION
Hello,
thank you for this extension but it wasn't working for me on Windows platform because
`vscode.window.activeTextEditor?.document.fileName`
was returning the full path with "\" instead of "/", I resolved this problem by using the same method you used to check the path
`vscode.workspace.asRelativePath`
This method returns the relative path with standard "/" even in Windows.

Let me know if something isn't clear.
Resolves the following issues: #2 #3 